### PR TITLE
Fix: Embed 2 missing learning video resources in Part 1 Set 1 in the …

### DIFF
--- a/doc/part-1-github-ui/set-1-github-ui-learning-videos-and-tasks.md
+++ b/doc/part-1-github-ui/set-1-github-ui-learning-videos-and-tasks.md
@@ -28,7 +28,15 @@ YouTube Video
 YouTube Video
 {% endembed %}
 
-Some other set 1 learning videos are not available yet. Check back on the 9th of October 2022.
+### Create, edit and delete files or folders using GITHUB UI)
+{% embed url="https://youtu.be/lqSdpFmT3y4" %}
+YouTube Video
+{% endembed %}
+
+### When to delete a branch connected to pull request or a fork
+{% embed url="https://youtu.be/K8PmM6mRLIo" %}
+YouTube Video
+{% endembed %}
 
 ## Tasks
 


### PR DESCRIPTION
…Gitbook learning resource

**This pull request makes the following changes:**
* Fixes issue #39 
* I worked on [set-1-github-ui-learning-videos-and-tasks.md]
* (https://github.com/rk-1620/git-github-training-resource/blob/new-test-branch/doc/part-1-github-ui/set-1-github-ui-learning-videos-and-tasks.md)

**Checklist:**
- [x] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me
- [x] I certify that I ran my checklist.

Ping @Ifycode/git-github-training-resource
